### PR TITLE
Add a new paper (EdgeRazor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If you find this repo useful, please consider **★STARing** and feel free to sh
 
 ## Transformer-based Models
 ### Language Transformers
+- "EdgeRazor: A Lightweight Framework for Large Language Models via Mixed-Precision Quantization-Aware Distillation", arXiv, 2026. [[paper](https://arxiv.org/abs/2605.04062)] [[code](https://github.com/zhangsq-nju/EdgeRazor)] [[model](https://huggingface.co/collections/zhangsq-nju/edgerazor-nbit)] [[playground](https://huggingface.co/spaces/zhangsq-nju/EdgeRazor-PlayGround)] [**`QAD`**] [**`1.58-bit to 4-bit`**]
 - "CBQ: Cross-Block Quantization for Large Language Models", ICLR, 2025. [[paper](https://iclr.cc/virtual/2025/poster/28924)]
 - "SpinQuant: LLM Quantization with Learned Rotations", ICLR, 2025. [[paper](https://iclr.cc/virtual/2025/poster/28338)]
 - "LeanQuant: Accurate and Scalable Large Language Model Quantization with Loss-error-aware Grid", ICLR, 2025. [[paper](https://iclr.cc/virtual/2025/poster/30168)]


### PR DESCRIPTION
Hello,

Thank you for maintaining such a well-curated list of papers!

We are proposing **EdgeRazor**, a lightweight framework that compresses LLMs into flexible low-bit formats, achieving state-of-the-art performance in the sub-4-bit regime to facilitate resilient edge deployment. It supports **base**, **instruct**, and **multimodal LLMs**. We hope this would be a valuable addition to the [Transformer-based Models-Language Transformers](https://github.com/Zhen-Dong/Awesome-Quantization-Papers#language-transformers) section.

- **Paper**: https://arxiv.org/abs/2605.04062
- **Code**: https://github.com/zhangsq-nju/EdgeRazor
- **Model**: https://huggingface.co/collections/zhangsq-nju/edgerazor-nbit
- **Playground**: https://huggingface.co/spaces/zhangsq-nju/EdgeRazor-PlayGround

Thanks very much for your time and consideration!

Best regards, 
Letong Huang